### PR TITLE
Update HACS install resource config

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,7 +28,7 @@ marksie1988/atomic-calendar-revive
 7. If you edit your files directly, add the below to the `ui-lovelace.yaml` file :
 ```yaml
 resources:
-  - url: /local/community/atomic-calendar-revive/atomic-calendar-revive.js
+  - url: /hacsfiles/atomic-calendar-revive/atomic-calendar-revive.js
     type: module
 ```
 


### PR DESCRIPTION
The preferred way to integrate HACS installed component is with "/hacsfiles/" instead of "/local/community/".

Relevant docs: https://hacs.xyz/docs/categories/plugins#custom-view-hacsfiles